### PR TITLE
delivery_date is nullable

### DIFF
--- a/EasyPost/Rate.cs
+++ b/EasyPost/Rate.cs
@@ -16,7 +16,7 @@ namespace EasyPost {
         public string list_currency { get; set; }
         public string retail_currency { get; set; }
         public int est_delivery_days { get; set; }
-        public DateTime delivery_date {get; set; } 
+        public DateTime? delivery_date {get; set; } 
         public bool delivery_date_guaranteed {get; set;}
         public int delivery_days {get; set;}
         public string carrier { get; set; }


### PR DESCRIPTION
This field is returned as a null value in some cases. I encountered it while in both the EasyPost testing and production api environments.